### PR TITLE
Remove RedisSessionManager currentSessionSerializationMetadata after request

### DIFF
--- a/src/main/java/com/orangefunction/tomcat/redissessions/RedisSessionManager.java
+++ b/src/main/java/com/orangefunction/tomcat/redissessions/RedisSessionManager.java
@@ -10,9 +10,6 @@ import org.apache.catalina.Valve;
 import org.apache.catalina.Session;
 import org.apache.catalina.session.ManagerBase;
 
-import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
-import org.apache.commons.pool2.impl.BaseObjectPoolConfig;
-
 import redis.clients.util.Pool;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisSentinelPool;
@@ -22,7 +19,6 @@ import redis.clients.jedis.Protocol;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Set;
 import java.util.EnumSet;
@@ -668,6 +664,7 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
         currentSession.remove();
         currentSessionId.remove();
         currentSessionIsPersisted.remove();
+        currentSessionSerializationMetadata.remove();
         log.trace("Session removed from ThreadLocal :" + redisSession.getIdInternal());
       }
     }


### PR DESCRIPTION
Prevent errors on tomcat shutdown.

```
19-Oct-2015 11:21:03.444 SEVERE [localhost-startStop-2]
org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web
application [ROOT] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value
[java.lang.ThreadLocal@708011b2]) and a value of type
[com.orangefunction.tomcat.redissessions.SessionSerializationMetadata] (value
[com.orangefunction.tomcat.redissessions.SessionSerializationMetadata@da8b5f2]) but failed to remove
it when the web application was stopped. Threads are going to be renewed over time to try and avoid a
probable memory leak.
```
